### PR TITLE
Throw if `responseKey` does not exist in the response schema

### DIFF
--- a/src/lib/blueprint.ts
+++ b/src/lib/blueprint.ts
@@ -745,7 +745,7 @@ const createResponse = (
 
     if (!(responseKey in properties)) {
       throw new Error(
-        `Response key '${responseKey}' not found in response schema`,
+        `Response key '${responseKey}' not found in response schema for ${path}`,
       )
     }
 

--- a/src/lib/blueprint.ts
+++ b/src/lib/blueprint.ts
@@ -743,6 +743,12 @@ const createResponse = (
   ) {
     const properties = schema.properties
 
+    if (!(responseKey in properties)) {
+      throw new Error(
+        `Response key '${responseKey}' not found in response schema`,
+      )
+    }
+
     const refKey = responseKey
 
     if (refKey != null && properties[refKey] != null) {


### PR DESCRIPTION
Closes https://github.com/seamapi/blueprint/issues/50