### PR TITLE
Fix OpenapiOperationSchema compiled types

### DIFF
--- a/src/lib/openapi-schema.ts
+++ b/src/lib/openapi-schema.ts
@@ -72,7 +72,9 @@ export const OpenapiOperationSchema = z.object({
     })
     .optional(),
   responses: ResponseSchema,
-  security: z.array(z.record(AuthMethodSchema, z.array(z.never()))).default([]),
+  security: z
+    .array(z.record(z.string().pipe(AuthMethodSchema), z.array(z.never())))
+    .default([]),
   deprecated: z.boolean().default(false),
   'x-response-key': z.string().nullable().optional(),
   'x-title': z.string().default(''),


### PR DESCRIPTION
In AuthMethodSchema .catch() introduces the possibility of handling invalid values and because of that TypeScript seems to widen the type to unknown instead of keeping it as the strict union of string literals from the enum.
Found a solution here https://github.com/colinhacks/zod/discussions/1723#discussioncomment-4449900.